### PR TITLE
Bugfix - UART TXBUF issues

### DIFF
--- a/EMMS_Code_UserInterface.X/nbproject/configurations.xml
+++ b/EMMS_Code_UserInterface.X/nbproject/configurations.xml
@@ -90,7 +90,7 @@
         <property key="enable-omit-frame-pointer" value="false"/>
         <property key="enable-procedural-abstraction" value="false"/>
         <property key="enable-short-double" value="false"/>
-        <property key="enable-symbols" value="true"/>
+        <property key="enable-symbols" value="false"/>
         <property key="enable-unroll-loops" value="false"/>
         <property key="expand-pragma-config" value="false"/>
         <property key="extra-include-directories" value=""/>


### PR DESCRIPTION
The PIC24 UART TX buffer has issues - see the Eratta - document 80000522
This affects older silicon revisions, so it may work on some chips and not others

2 problems
The Transmit buffer may not work right if filled completely with 4 characters
The Transmit Buffer full flag may not work right allow characters to be written to the transmit buffer before it is ready

Our code runs smack into both of these issues.

Solution
check the Transmit Buffer Empty Flag (TRMT)
only put a character in the buffer if it is empty
this will use only one character at a time and not use the built-in buffering
that's ok - we did not specifically rely on it anyway